### PR TITLE
Made it so that once a cheatcode is entered, all keys are set to false.

### DIFF
--- a/game.js
+++ b/game.js
@@ -296,6 +296,9 @@ function activateCheat() {
   if (!cheatActivated) {
     cheatActivated = true;
     player.jumpBoost = true;
+    for (const [key, value] of Object.entries(keys)) {
+      keys[key] = false;
+    }
     alert('Cheat Activated: Jump Boost!\nHigh score will not update until refresh.');
   }
 }


### PR DESCRIPTION
To fix keys getting stuck after a cheatcode sequence had been entered, we now iterate over all the keys and simply set them to false after a sequence has been detected.